### PR TITLE
Add debug zone

### DIFF
--- a/src/zone_man_cmd.erl
+++ b/src/zone_man_cmd.erl
@@ -20,14 +20,26 @@ parse_machine_zones([H|T], Zones) ->
     parse_machine_zones(T, [Zone|Zones]).
 
 parse_machine_zone(MZ) ->
-    [ID, Name, Status, Path, UUID, Brand, IPType] = re:split(MZ, ":"),
-    [{id, ID},
-     {name, Name},
-     {status, Status},
-     {path, Path},
-     {uuid, UUID},
-     {brand, Brand},
-     {iptype, IPType}].
+    case re:split(MZ, ":") of
+        [ID, Name, Status, Path, UUID, Brand, IPType] ->
+            [{id, ID},
+             {name, Name},
+             {status, Status},
+             {path, Path},
+             {uuid, UUID},
+             {brand, Brand},
+             {iptype, IPType}];
+        [ID, Name, Status, Path, UUID, Brand, IPType, DebugID] ->
+            [{id, ID},
+             {name, Name},
+             {status, Status},
+             {path, Path},
+             {uuid, UUID},
+             {brand, Brand},
+             {iptype, IPType},
+             {debugid, DebugID}]
+    end.
+
 
 
 run(CMD, Options) ->

--- a/test/zone_man_cmd_test.erl
+++ b/test/zone_man_cmd_test.erl
@@ -16,3 +16,17 @@ parse_machine_zone_test() ->
                 {brand, <<"native">>},
                 {iptype, <<"excl">>}],
     ?assertEqual(Expected, Zone).
+
+parse_machine_zone_with_debug_id_test() ->
+    MZ = "2:dev:running:/:4872c422-3ad9-4b99-8b9a-a416f282b866:native:excl:1",
+    Zone = ?MUT:parse_machine_zone(MZ),
+
+    Expected = [{id, <<"2">>},
+                {name, <<"dev">>},
+                {status, <<"running">>},
+                {path, <<"/">>},
+                {uuid, <<"4872c422-3ad9-4b99-8b9a-a416f282b866">>},
+                {brand, <<"native">>},
+                {iptype, <<"excl">>},
+                {debugid, <<"1">>}],
+    ?assertEqual(Expected, Zone).


### PR DESCRIPTION
Now included in the output of zoned

```
                 zoneid:zonename:state:zonepath:uuid:brand:ip-type:debugid

 The debugid value is
               a constant numeric identifier which is attached to the zone and
               can be used by tools such as DTrace to track zones across
               reboots (since zoneid will change).  Any software that parses
               the output of the "zoneadm list -p" command must be able to
               handle any fields that may be added in the future.
```